### PR TITLE
pipe jspm logging to `grunt.log`

### DIFF
--- a/tasks/jspm.js
+++ b/tasks/jspm.js
@@ -2,10 +2,13 @@
 
 module.exports = function (grunt) {
     var config = require("jspm/lib/config");
+    var format = require("jspm/lib/ui").format;
 
     // jspm for simple builds
     var jspm = require("jspm");
     jspm.setPackagePath(".");
+
+    jspm.on('log', (type, msg) => grunt.log.writeln(format[type](msg)));
 
     // SystemJS Builder
     const builder = new jspm.Builder();


### PR DESCRIPTION
To get (almost) same output as running `jspm` pipe
logging to `grunt.log` as mentioned in `jspm/api.js`:

```
/*
 * jspm.on('log', function(type, msg) { console.log(msg); });
 * jspm.on('prompt', function(prompt, callback) {
 *   if (prompt.type == 'confirm')
 *     callback({ confirm: true });
 *   if (prompt.type == 'input')
 *     callback({ input: value });
 * });
 *
 * Prompt as defined in https://github.com/SBoudrias/Inquirer.js/tree/master#question
 * Callback answer defined in https://github.com/SBoudrias/Inquirer.js/tree/master#answers
 */
```
